### PR TITLE
Feature/05.linq

### DIFF
--- a/05.LINQ/Expressions and IQueryable.Tasks.Week2_updated/Expressions.Task3.E3SQueryProvider.Test/E3SAndOperatorSupportTests.cs
+++ b/05.LINQ/Expressions and IQueryable.Tasks.Week2_updated/Expressions.Task3.E3SQueryProvider.Test/E3SAndOperatorSupportTests.cs
@@ -7,10 +7,10 @@
  * imply the following rules: https://kb.epam.com/display/EPME3SDEV/Telescope+public+REST+for+data#TelescopepublicRESTfordata-FTSRequestSyntax
  */
 
+using Expressions.Task3.E3SQueryProvider.Models.Entities;
 using System;
 using System.Linq;
 using System.Linq.Expressions;
-using Expressions.Task3.E3SQueryProvider.Models.Entities;
 using Xunit;
 
 namespace Expressions.Task3.E3SQueryProvider.Test
@@ -35,7 +35,9 @@ namespace Expressions.Task3.E3SQueryProvider.Test
              */
 
             // todo: create asserts for this test by yourself, because they will depend on your final implementation
-            throw new NotImplementedException("Please implement this test and the appropriate functionality");
+            var result = translator.Translate(expression);
+
+            Assert.Equal("Workstation:(EPRUIZHW006) AND Manager:(John*)", result);
         }
 
         #endregion

--- a/05.LINQ/Expressions and IQueryable.Tasks.Week2_updated/Expressions.Task3.E3SQueryProvider.Test/Expressions.Task3.E3SQueryProvider.Test.csproj
+++ b/05.LINQ/Expressions and IQueryable.Tasks.Week2_updated/Expressions.Task3.E3SQueryProvider.Test/Expressions.Task3.E3SQueryProvider.Test.csproj
@@ -1,18 +1,18 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.9.0" />
-    <PackageReference Include="Moq" Version="4.13.1" />
-    <PackageReference Include="Newtonsoft.Json" Version="12.0.2" />
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.0.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.8.0" />
+    <PackageReference Include="Moq" Version="4.20.70" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+    <PackageReference Include="xunit" Version="2.6.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.5.4">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/05.LINQ/Expressions and IQueryable.Tasks.Week2_updated/Expressions.Task3.E3SQueryProvider/Expressions.Task3.E3SQueryProvider.csproj
+++ b/05.LINQ/Expressions and IQueryable.Tasks.Week2_updated/Expressions.Task3.E3SQueryProvider/Expressions.Task3.E3SQueryProvider.csproj
@@ -1,10 +1,15 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
 
     <IsPackable>false</IsPackable>
   </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.AspNetCore.WebUtilities" Version="8.0.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.3" />
+  </ItemGroup>
 
   <ItemGroup>
     <Reference Include="Microsoft.AspNetCore.WebUtilities">

--- a/05.LINQ/Expressions and IQueryable.Tasks.Week2_updated/Expressions.Task3.E3SQueryProvider/Helpers/Brackets.cs
+++ b/05.LINQ/Expressions and IQueryable.Tasks.Week2_updated/Expressions.Task3.E3SQueryProvider/Helpers/Brackets.cs
@@ -1,0 +1,14 @@
+﻿namespace Expressions.Task3.E3SQueryProvider.Helpers
+{
+    public class Brackets
+    {
+        public string Left { get; }
+        public string Right { get; }
+
+        public Brackets(string left, string right)
+        {
+            Left = left;
+            Right = right;
+        }
+    }
+}

--- a/05.LINQ/Expressions and IQueryable.Tasks.Week2_updated/Expressions.Task3.E3SQueryProvider/Helpers/QueryHelper.cs
+++ b/05.LINQ/Expressions and IQueryable.Tasks.Week2_updated/Expressions.Task3.E3SQueryProvider/Helpers/QueryHelper.cs
@@ -1,0 +1,22 @@
+﻿using System.Collections.Generic;
+
+namespace Expressions.Task3.E3SQueryProvider.Helpers
+{
+    public static class QueryHelper
+    {
+        public static readonly IReadOnlyDictionary<string, Brackets> QueryTranslator = new Dictionary<string, Brackets>
+        {
+            {"Equals", new Brackets("(", ")") },
+            {"StartsWith", new Brackets("(", "*)") },
+            {"EndsWith", new Brackets ("(*", ")") },
+            {"Contains", new Brackets("(*", "*)") }
+        };
+
+        public static readonly string[] Operators = new string[] { Operator.And };
+
+        public static class Operator
+        {
+            public const string And = "AND";
+        }
+    }
+}

--- a/05.LINQ/Expressions and IQueryable.Tasks.Week2_updated/Expressions.Task3.E3SQueryProvider/Models/Request/FTSQueryRequest.cs
+++ b/05.LINQ/Expressions and IQueryable.Tasks.Week2_updated/Expressions.Task3.E3SQueryProvider/Models/Request/FTSQueryRequest.cs
@@ -9,9 +9,9 @@ namespace Expressions.Task3.E3SQueryProvider.Models.Request
         public FtsQueryRequest()
         {
             // todo: remove that
-            // Statements = new List<Statement>();
-            // Filters = new List<Filter>();
-            // Sorting = new SortingCollection();
+            Statements = new List<Statement>();
+            Filters = new List<Filter>();
+            Sorting = new SortingCollection();
         }
 
         [JsonProperty("statements")]


### PR DESCRIPTION
Task: Complete the following LINQ provider. 
Note: Use Unit Tests from the Expressions.Task3.E3SQueryProvider.Test.csproj project to validate the task. 
 
It is required to do the following: 

1. Remove the expression operands ordering restriction. The following cases should be allowed: 
`<filtered field name> == <constant>` (only this one is allowed now) 
`<constant> == <filtered field name>` 
2. Test: FTSRequestTranslatorTests.cs, #region SubTask 1: operands order
Add include operations support (partial, not exact match). At the same time LINQ notations should look like string class methods calls: StartsWith, EndsWith, Contains. 
Test: FTSRequestTranslatorTests.cs, #region SubTask 2: inclusion operations
3. Add AND operator support (requires extension of E3SsearchService itself, and probably it will be needed to actualize the existing tests). How to organize AND operator in the E3S request please check [in documentation](https://kb.epam.com/display/EPME3SDEV/Telescope+public+REST+for+data#TelescopepublicRESTfordata-FTSRequestSyntax) (FTS Request Syntax) 
Test: E3SAndOperatorSupportTests.cs, #region SubTask 3: AND operator support